### PR TITLE
feat: delay send questions

### DIFF
--- a/apps/client/components/organisms/NewExamForm/Summary.tsx
+++ b/apps/client/components/organisms/NewExamForm/Summary.tsx
@@ -62,11 +62,6 @@ export const Summary = ({
     if (blockchainCallStatus === 'Success' && examUpdateStatus === 'success')
       return 'Success!';
 
-    // if (
-    //   blockchainCallStatus === 'PendingSignature' ||
-    //   blockchainCallStatus === 'Mining' ||
-    //   examUpdateStatus === 'loading'
-    // )
     return 'Loading...';
   };
 

--- a/apps/client/components/organisms/NewExamForm/Summary.tsx
+++ b/apps/client/components/organisms/NewExamForm/Summary.tsx
@@ -59,19 +59,24 @@ export const Summary = ({
     )
       return 'Oops, something went wrong!';
 
-    if (
-      blockchainCallStatus === 'PendingSignature' ||
-      blockchainCallStatus === 'Mining' ||
-      examUpdateStatus === 'loading'
-    )
-      return 'Loading...';
-
     if (blockchainCallStatus === 'Success' && examUpdateStatus === 'success')
       return 'Success!';
+
+    // if (
+    //   blockchainCallStatus === 'PendingSignature' ||
+    //   blockchainCallStatus === 'Mining' ||
+    //   examUpdateStatus === 'loading'
+    // )
+    return 'Loading...';
   };
 
   const onSubmitExam = (newExam: NewExam) => {
-    if (!isAddingDisabled()) addNewExam(newExam);
+    if (isAddingDisabled()) return;
+    addNewExam(newExam);
+
+    alert(
+      'DO NOT close or change the page, otherwise the questions will not be added!'
+    );
   };
 
   return (

--- a/apps/client/components/organisms/NewExamForm/useAddExam.ts
+++ b/apps/client/components/organisms/NewExamForm/useAddExam.ts
@@ -75,11 +75,13 @@ export const useAddExam = () => {
 
     const examAddress = newExamCreation.args[0];
 
-    mutate({
-      userAddress: account as string,
-      examAddress,
-      exam,
-    });
+    setTimeout(() => {
+      mutate({
+        userAddress: account as string,
+        examAddress,
+        exam,
+      });
+    }, 1000);
   }, [events, account, exam, mutate, findUserExamAddress]);
 
   return {


### PR DESCRIPTION
- due to the problems that occured from time to time I decided to delay sending a questions to backend. There was situation when backend hasn't create the Exam entry with basic information and client app wanted to interact with exam that didn't exist.

- add displaying alert when adding an exam to warn the user to not leave the page